### PR TITLE
Update egg-open-t-t-d-server.json

### DIFF
--- a/openttd/egg-open-t-t-d-server.json
+++ b/openttd/egg-open-t-t-d-server.json
@@ -16,7 +16,7 @@
     "startup": ".\/openttd -D",
     "config": {
         "files": "{\r\n    \"openttd.cfg\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"network.server_port\": \"{{server.build.default.port}}\",\r\n            \"network.server_name\": \"{{server.build.env.srv_name}}\",\r\n            \"network.lan_internet\": 0,\r\n            \"network.server_advertise\": \"{{server.build.env.srv_advertise}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"[net] Map generated, starting game\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Map generated, starting game\"\r\n}",
         "logs": "{}",
         "stop": "exit"
     },
@@ -52,7 +52,7 @@
             "name": "OpenTTD Version",
             "description": "The version of OpenTTD i.e. 12.2",
             "env_variable": "OPENTTD_VERSION",
-            "default_value": "13.0-RC2",
+            "default_value": "14.1",
             "user_viewable": true,
             "user_editable": false,
             "rules": "required|string|max:20",


### PR DESCRIPTION
Updated OpenTTD to newer version. Fixed the startup config.

# Description

Upgraded the default OpenTTD version number to the lts. And changed the startup string to work cause now its possible it doesnt get detected its done starting.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [ ] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel