### PR TITLE
Spacestation 14: fix download link

### DIFF
--- a/spacestation_14/egg-pterodactyl-spacestation14.json
+++ b/spacestation_14/egg-pterodactyl-spacestation14.json
@@ -1,30 +1,30 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T00:17:09+00:00",
+    "exported_at": "2024-08-14T20:05:17+02:00",
     "name": "Spacestation 14",
     "author": "josdekurk@gmail.com",
     "description": "Space Station 14 tells the story of an ordinary shift on a space station gone wrong. Immerse yourself into your role, tinker with detailed systems, and survive the chaos in this round-based multiplayer role playing game.",
-    "features": null,
+    "features": [],
     "docker_images": {
-        "Dotnet 8": "ghcr.io/parkervcp/yolks:dotnet_8"
+        "Dotnet 8": "ghcr.io\/parkervcp\/yolks:dotnet_8"
     },
     "file_denylist": [],
-    "startup": "./Robust.Server",
+    "startup": ".\/Robust.Server",
     "config": {
         "files": "{\r\n    \"server_config.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"port\": \"port = {{server.build.default.port}}\",\r\n            \"hostname\": \"hostname = \\\"{{server.build.env.SERVER_NAME}}\\\"\",\r\n            \"tickrate\": \"tickrate = {{server.build.env.SERVER_TICK}}\",\r\n            \"max_connections\": \"max_connections = {{server.build.env.SERVER_MAX_PLAYERS}}\"\r\n        }\r\n    }\r\n}",
-        "logs": "{}",
         "startup": "{\r\n    \"done\": \"Server Version\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "bash",
-            "script": "#!/bin/bash\r\n\r\nV=$(curl -sSL https://central.spacestation14.io/builds/wizards/builds.html | grep \"The version is\"  | sed -n 's/.*\u003cspan class=\"versionNumber\"\u003e\\([^\u003c]*\\)\u003c\\/span\u003e.*/\\1/p')\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] \u0026\u0026 echo \"linux-x64\" || echo \"linux-arm64\")\r\n\r\nmkdir -p /mnt/server\r\ncd /mnt/server\r\n\r\necho \"Running: curl -sSL -o server_linux.zip https://cdn.centcomm.spacestation14.com/builds/wizards/builds/${V}/SS14.Server_${ARCH}.zip\"\r\ncurl -sSL -o server_linux.zip \"https://cdn.centcomm.spacestation14.com/builds/wizards/builds/${V}/SS14.Server_${ARCH}.zip\"\r\nunzip -o server_linux.zip\r\nrm server_linux.zip\r\n\r\nchmod +x Robust.Server\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\""
+            "script": "#!\/bin\/bash\r\n\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"x64\" || echo \"arm64\")\r\nV=$(curl -sSL https:\/\/wizards.cdn.spacestation14.com\/fork\/wizards | grep \".Server_linux\" | grep -i ${ARCH} | head -1 | awk '{print $2}' | sed 's\/^href=\"\/\/;s\/\">Linux\/\/')\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\necho \"Running: curl -sSL -o server_linux.zip https:\/\/wizards.cdn.spacestation14.com\/${V}\"\r\ncurl -sSL -o server_linux.zip \"https:\/\/wizards.cdn.spacestation14.com\/${V}\"\r\nunzip -o server_linux.zip\r\nrm server_linux.zip\r\n\r\nchmod +x Robust.Server\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
         }
     },
     "variables": [

--- a/spacestation_14/egg-spacestation14.json
+++ b/spacestation_14/egg-spacestation14.json
@@ -4,32 +4,33 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:17:09+00:00",
+    "exported_at": "2024-08-14T20:05:17+02:00",
     "name": "Spacestation 14",
     "author": "josdekurk@gmail.com",
     "uuid": "ef79fd90-64e9-4387-b862-af0042ed2d28",
     "description": "Space Station 14 tells the story of an ordinary shift on a space station gone wrong. Immerse yourself into your role, tinker with detailed systems, and survive the chaos in this round-based multiplayer role playing game.",
-    "features": null,
+    "features": [],
     "docker_images": {
         "Dotnet 8": "ghcr.io\/parkervcp\/yolks:dotnet_8"
     },
     "file_denylist": [],
     "startup": ".\/Robust.Server",
     "config": {
-        "files": "{\r\n    \"server_config.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"port\": \"port = {{server.build.default.port}}\",\r\n            \"hostname\": \"hostname = \\\"{{server.build.env.SERVER_NAME}}\\\"\",\r\n            \"tickrate\": \"tickrate = {{server.build.env.SERVER_TICK}}\",\r\n            \"max_connections\": \"max_connections = {{server.build.env.SERVER_MAX_PLAYERS}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"server_config.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"port\": \"port = {{server.allocations.default.port}}\",\r\n            \"hostname\": \"hostname = \\\"{{server.environment.SERVER_NAME}}\\\"\",\r\n            \"tickrate\": \"tickrate = {{server.environment.SERVER_TICK}}\",\r\n            \"max_connections\": \"max_connections = {{server.environment.SERVER_MAX_PLAYERS}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server Version\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\nV=$(curl -sSL https:\/\/central.spacestation14.io\/builds\/wizards\/builds.html | grep \"The version is\"  | sed -n 's\/.*<span class=\"versionNumber\">\\([^<]*\\)<\\\/span>.*\/\\1\/p')\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"linux-x64\" || echo \"linux-arm64\")\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\necho \"Running: curl -sSL -o server_linux.zip https:\/\/cdn.centcomm.spacestation14.com\/builds\/wizards\/builds\/${V}\/SS14.Server_${ARCH}.zip\"\r\ncurl -sSL -o server_linux.zip \"https:\/\/cdn.centcomm.spacestation14.com\/builds\/wizards\/builds\/${V}\/SS14.Server_${ARCH}.zip\"\r\nunzip -o server_linux.zip\r\nrm server_linux.zip\r\n\r\nchmod +x Robust.Server\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "script": "#!\/bin\/bash\r\n\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"x64\" || echo \"arm64\")\r\nV=$(curl -sSL https:\/\/wizards.cdn.spacestation14.com\/fork\/wizards | grep \".Server_linux\" | grep -i ${ARCH} | head -1 | awk '{print $2}' | sed 's\/^href=\"\/\/;s\/\">Linux\/\/')\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\necho \"Running: curl -sSL -o server_linux.zip https:\/\/wizards.cdn.spacestation14.com\/${V}\"\r\ncurl -sSL -o server_linux.zip \"https:\/\/wizards.cdn.spacestation14.com\/${V}\"\r\nunzip -o server_linux.zip\r\nrm server_linux.zip\r\n\r\nchmod +x Robust.Server\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
     },
     "variables": [
         {
+            "sort": 1,
             "name": "Server name",
             "description": "The server hostname",
             "env_variable": "SERVER_NAME",
@@ -37,10 +38,10 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:48",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 2,
             "name": "Server tickrate",
             "description": "The tickrate of the server. Default is 60",
             "env_variable": "SERVER_TICK",
@@ -48,10 +49,10 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|numeric|between:1,80",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 3,
             "name": "Max players",
             "description": "",
             "env_variable": "SERVER_MAX_PLAYERS",
@@ -59,7 +60,6 @@
             "user_viewable": true,
             "user_editable": false,
             "rules": "required|numeric|between:1,256",
-            "sort": null,
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
# Description

Fixes the install logic as there download page changed


## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->
