### PR TITLE
config control mechanism

### DIFF
--- a/gta/altv/egg-alt--v.json
+++ b/gta/altv/egg-alt--v.json
@@ -4,19 +4,19 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:17:23+00:00",
+    "exported_at": "2024-08-24T08:07:23+00:00",
     "name": "alt:V",
     "author": "parker@parkervcp.com",
     "uuid": "25408807-f3c9-47d0-bed1-1d3f071b869e",
     "description": "alt:V Multiplayer a third-party multiplayer modification for Grand Theft Auto: V",
-    "features": null,
+    "features": [],
     "docker_images": {
         "ALT:V": "ghcr.io\/parkervcp\/games:altv"
     },
     "file_denylist": [],
-    "startup": ".\/altv-server",
+    "startup": ".\/altv-server --port {{SERVER_PORT}}",
     "config": {
-        "files": "{\r\n    \"server.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"host:\": \"host: 0.0.0.0\",\r\n            \"port:\": \"port: {{server.build.default.port}}\",\r\n            \"password:\": \"password: {{server.build.env.PASSWORD}}\",\r\n            \"description:\": \"description: {{server.build.env.SERVER_DESC}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\n    \"server.toml\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"host:\": \"host: 0.0.0.0\",\n            \"password:\": \"password: {{server.environment.PASSWORD}}\",\n            \"description:\": \"description: {{server.environment.SERVER_DESC}}\"\n        }\n    }\n}",
         "startup": "{\r\n    \"done\": \"Server started\"\r\n}",
         "logs": "{}",
         "stop": "quit"
@@ -30,6 +30,7 @@
     },
     "variables": [
         {
+            "sort": 1,
             "name": "ld lib path",
             "description": "Needed to load modules correctly. Best left at default.",
             "env_variable": "LD_LIBRARY_PATH",
@@ -37,10 +38,10 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|max:20",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 2,
             "name": "Release Branch",
             "description": "The supported versions are release, rc, dev (default: release).\r\nIf you don't know what you are doing leave it on release",
             "env_variable": "BUILD",
@@ -48,10 +49,10 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:release,rc,dev",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 3,
             "name": "Server Password",
             "description": "The password to join the server",
             "env_variable": "PASSWORD",
@@ -59,10 +60,10 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string|min:6",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 4,
             "name": "Server Description",
             "description": "Description for the server.",
             "env_variable": "SERVER_DESC",
@@ -70,7 +71,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string",
-            "sort": null,
             "field_type": "text"
         }
     ]

--- a/gta/altv/egg-pterodactyl-alt--v.json
+++ b/gta/altv/egg-pterodactyl-alt--v.json
@@ -13,7 +13,7 @@
         "ALT:V": "ghcr.io/parkervcp/games:altv"
     },
     "file_denylist": [],
-    "startup": "./altv-server",
+    "startup": "./altv-server --port {{SERVER_PORT}}",
     "config": {
         "files": "{\r\n    \"server.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"host:\": \"host: 0.0.0.0\",\r\n            \"port:\": \"port: {{server.build.default.port}}\",\r\n            \"password:\": \"password: {{server.build.env.PASSWORD}}\",\r\n            \"description:\": \"description: {{server.build.env.SERVER_DESC}}\"\r\n        }\r\n    }\r\n}",
         "logs": "{}",

--- a/gta/altv/egg-pterodactyl-alt--v.json
+++ b/gta/altv/egg-pterodactyl-alt--v.json
@@ -1,30 +1,30 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T00:17:23+00:00",
+    "exported_at": "2024-08-24T10:06:02+02:00",
     "name": "alt:V",
     "author": "parker@parkervcp.com",
     "description": "alt:V Multiplayer a third-party multiplayer modification for Grand Theft Auto: V",
     "features": null,
     "docker_images": {
-        "ALT:V": "ghcr.io/parkervcp/games:altv"
+        "ALT_V": "ghcr.io\/parkervcp\/games:altv"
     },
     "file_denylist": [],
-    "startup": "./altv-server --port {{SERVER_PORT}}",
+    "startup": ".\/altv-server --port {{SERVER_PORT}}",
     "config": {
-        "files": "{\r\n    \"server.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"host:\": \"host: 0.0.0.0\",\r\n            \"port:\": \"port: {{server.build.default.port}}\",\r\n            \"password:\": \"password: {{server.build.env.PASSWORD}}\",\r\n            \"description:\": \"description: {{server.build.env.SERVER_DESC}}\"\r\n        }\r\n    }\r\n}",
-        "logs": "{}",
+        "files": "{\r\n    \"server.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"host:\": \"host: 0.0.0.0\",\r\n            \"password:\": \"password: {{server.build.env.PASSWORD}}\",\r\n            \"description:\": \"description: {{server.build.env.SERVER_DESC}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server started\"\r\n}",
+        "logs": "{}",
         "stop": "quit"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "bash",
-            "script": "#!/bin/bash\r\n#\r\n\r\napt update\r\napt install -y wget jq curl \r\n\r\ncd /mnt/server\r\nNEWVERSION=$(curl -sSL https://cdn.alt-mp.com/server/${BUILD}/x64_linux/update.json | jq -r .version)\r\n\r\n\r\nif [ -f \"/mnt/server/altv-server\" ]; then\r\n    CURRENTVERSION=$(cat update.json | jq -r .version)\r\n    if [[ \"${CURRENTVERSION}\" == \"${NEWVERSION}\" ]]; then\r\n        echo \"No update found\"\r\n        exit 0\r\n    fi\r\n    echo \"Backing up version ${CURRENTVERSION}\"\r\n    mkdir -p /mnt/server/backup/${CURRENTVERSION}/data\r\n    mv altv-server /mnt/server/backup/${CURRENTVERSION}/\r\n    cd /mnt/server/data\r\n    mv clothes.bin /mnt/server/backup/${CURRENTVERSION}/data\r\n    mv vehmodels.bin /mnt/server/backup/${CURRENTVERSION}/data\r\n    mv vehmods.bin /mnt/server/backup/${CURRENTVERSION}/data\r\n    mv pedmodels.bin /mnt/server/backup/${CURRENTVERSION}/data\r\n    mv weaponmodels.bin /mnt/server/backup/${CURRENTVERSION}/data\r\n    mv rpfdata.bin /mnt/server/backup/${CURRENTVERSION}/data\r\n    rm /mnt/server/update.json\r\nfi\r\n\r\n\r\ncd /mnt/server\r\n\r\n\r\necho \"Installing version: ${NEWVERSION}\"\r\nwget -q https://cdn.alt-mp.com/server/${BUILD}/x64_linux/altv-server\r\nwget -q https://cdn.alt-mp.com/server/${BUILD}/x64_linux/update.json\r\nchmod +x ./altv-server\r\n\r\n\r\nmkdir -p /mnt/server/data\r\ncd /mnt/server/data\r\n\r\nwget -q https://cdn.alt-mp.com/data/${BUILD}/data/vehmodels.bin\r\nwget -q https://cdn.alt-mp.com/data/${BUILD}/data/vehmods.bin\r\nwget -q https://cdn.alt-mp.com/data/${BUILD}/data/clothes.bin\r\nwget -q https://cdn.alt-mp.com/data/${BUILD}/data/pedmodels.bin\r\nwget -q https://cdn.alt-mp.com/data/${BUILD}/data/weaponmodels.bin\r\nwget -q https://cdn.alt-mp.com/data/${BUILD}/data/rpfdata.bin\r\n\r\n\r\n\r\n\r\ncd /mnt/server\r\nif [ ! -f \"/mnt/server/server.toml\" ]; then\r\ncat \u003c\u003c EOF \u003e\u003e server.toml\r\nname = 'alt:V Server'\r\nhost = '0.0.0.0'\r\nport = ${SERVER_PORT}\r\nplayers = 128\r\npassword = '${PASSWORD}'\r\nannounce = false\r\ntoken = 'YOUR_TOKEN'\r\ngamemode = 'Freeroam'\r\nwebsite = 'example.com'\r\nlanguage = 'en'\r\ndescription = '${SERVER_DESC}'\r\nmodules = []\r\nresources = []\r\nEOF\r\nfi\r\n\r\nmkdir -p resources/\r\n\r\necho -e \"install complete\""
+            "script": "#!\/bin\/bash\r\n#\r\n\r\napt update\r\napt install -y wget jq curl \r\n\r\ncd \/mnt\/server\r\nNEWVERSION=$(curl -sSL https:\/\/cdn.alt-mp.com\/server\/${BUILD}\/x64_linux\/update.json | jq -r .version)\r\n\r\n\r\nif [ -f \"\/mnt\/server\/altv-server\" ]; then\r\n    CURRENTVERSION=$(cat update.json | jq -r .version)\r\n    if [[ \"${CURRENTVERSION}\" == \"${NEWVERSION}\" ]]; then\r\n        echo \"No update found\"\r\n        exit 0\r\n    fi\r\n    echo \"Backing up version ${CURRENTVERSION}\"\r\n    mkdir -p \/mnt\/server\/backup\/${CURRENTVERSION}\/data\r\n    mv altv-server \/mnt\/server\/backup\/${CURRENTVERSION}\/\r\n    cd \/mnt\/server\/data\r\n    mv clothes.bin \/mnt\/server\/backup\/${CURRENTVERSION}\/data\r\n    mv vehmodels.bin \/mnt\/server\/backup\/${CURRENTVERSION}\/data\r\n    mv vehmods.bin \/mnt\/server\/backup\/${CURRENTVERSION}\/data\r\n    mv pedmodels.bin \/mnt\/server\/backup\/${CURRENTVERSION}\/data\r\n    mv weaponmodels.bin \/mnt\/server\/backup\/${CURRENTVERSION}\/data\r\n    mv rpfdata.bin \/mnt\/server\/backup\/${CURRENTVERSION}\/data\r\n    rm \/mnt\/server\/update.json\r\nfi\r\n\r\n\r\ncd \/mnt\/server\r\n\r\n\r\necho \"Installing version: ${NEWVERSION}\"\r\nwget -q https:\/\/cdn.alt-mp.com\/server\/${BUILD}\/x64_linux\/altv-server\r\nwget -q https:\/\/cdn.alt-mp.com\/server\/${BUILD}\/x64_linux\/update.json\r\nchmod +x .\/altv-server\r\n\r\n\r\nmkdir -p \/mnt\/server\/data\r\ncd \/mnt\/server\/data\r\n\r\nwget -q https:\/\/cdn.alt-mp.com\/data\/${BUILD}\/data\/vehmodels.bin\r\nwget -q https:\/\/cdn.alt-mp.com\/data\/${BUILD}\/data\/vehmods.bin\r\nwget -q https:\/\/cdn.alt-mp.com\/data\/${BUILD}\/data\/clothes.bin\r\nwget -q https:\/\/cdn.alt-mp.com\/data\/${BUILD}\/data\/pedmodels.bin\r\nwget -q https:\/\/cdn.alt-mp.com\/data\/${BUILD}\/data\/weaponmodels.bin\r\nwget -q https:\/\/cdn.alt-mp.com\/data\/${BUILD}\/data\/rpfdata.bin\r\n\r\n\r\n\r\n\r\ncd \/mnt\/server\r\nif [ ! -f \"\/mnt\/server\/server.toml\" ]; then\r\ncat << EOF >> server.toml\r\nname = 'alt:V Server'\r\nhost = '0.0.0.0'\r\nport = ${SERVER_PORT}\r\nplayers = 128\r\npassword = '${PASSWORD}'\r\nannounce = false\r\ntoken = 'YOUR_TOKEN'\r\ngamemode = 'Freeroam'\r\nwebsite = 'example.com'\r\nlanguage = 'en'\r\ndescription = '${SERVER_DESC}'\r\nmodules = []\r\nresources = []\r\nEOF\r\nfi\r\n\r\nmkdir -p resources\/\r\n\r\necho -e \"install complete\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
         }
     },
     "variables": [


### PR DESCRIPTION
# Description

Added config control mechanism for {{SERVER_PORT}} in the startup command ./altv-server, since alt:v supports the --port startup parameter. The port can no longer be mangled with by user.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel