### PR TITLE
Update Hogwarp

### DIFF
--- a/hogwarp/README.md
+++ b/hogwarp/README.md
@@ -5,6 +5,9 @@ HogWarp is a Work In Progress mod that adds Multiplayer functionality to Hogwart
 This Mod requires a API key only obtainable through their Discord, see the Startup Variable **API KEY** for more info.
 - Some features of the mod (Public servers / higher player counts) require a Patreon level. See their Patreon here: https://www.patreon.com/tiltedphoques
 
+# Important Info
+The Server files are *exclusivily* in their Discord, to install you can either manually upload the Zip and unarchive after server creation; or upload the data to your own source and update the *DOWNLOAD_URL* variable
+
 ## Server Port
 | Port    | default |
 |---------|---------|

--- a/hogwarp/egg-hogwarp.json
+++ b/hogwarp/egg-hogwarp.json
@@ -4,128 +4,153 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:16:49+00:00",
+    "exported_at": "2024-10-20T18:23:50+00:00",
     "name": "Hogwarp",
     "author": "imkringle@proton.me",
     "uuid": "9ae78c9d-1d23-4b67-8a58-5c8fca30c124",
     "description": "A Pterodactyl egg for the Hogwarts Legacy mod Hogwarp - For more info see their Nexus: https:\/\/www.nexusmods.com\/hogwartslegacy\/mods\/1378",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:wine_staging": "ghcr.io\/parkervcp\/yolks:wine_staging"
+        "ghcr.io\/parkervcp\/yolks:wine_latest": "ghcr.io\/parkervcp\/yolks:wine_latest"
     },
     "file_denylist": [],
     "startup": "export WINEDLLOVERRIDES=\"mscoree=n,b;mshtml=n,b\"; wine HogWarpServer.exe",
     "config": {
-        "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ApiKey\": \"{{env.API_KEY}}\",\r\n            \"Name\": \"{{env.SERV_NAME}}\",\r\n            \"Port\": \"{{server.build.default.port}}\",\r\n            \"Description\": \"{{env.SERV_DESC}}\",\r\n            \"MaxPlayer\": \"{{env.MAX_PLAYERS}}\",\r\n            \"IconUrl\": \"{{env.SERV_ICON}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ApiKey\": \"{{env.API_KEY}}\",\r\n            \"Name\": \"{{env.SERV_NAME}}\",\r\n            \"Port\": \"{{server.allocations.default.port}}\",\r\n            \"Description\": \"{{env.SERV_DESC}}\",\r\n            \"MaxPlayer\": \"{{env.MAX_PLAYERS}}\",\r\n            \"IconUrl\": \"{{env.SERV_ICON}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server started on port \"\r\n}",
         "logs": "{}",
         "stop": "^^C"
     },
     "scripts": {
         "installation": {
-            "script": "#Hogwarp Install\r\napt update -y\r\napt install -y curl file unzip\r\n\r\nif [ ! -d \/mnt\/server ]; then\r\n    mkdir -p \/mnt\/server\/\r\nfi\r\n\r\ncd \/mnt\/server\/\r\n\r\n# Validate link\r\nif [ ! -z \"${DOWNLOAD_URL}\" ]; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_URL}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_URL}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_URL}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\ncurl -sSL ${DOWNLOAD_LINK} -o ${DOWNLOAD_LINK##*\/}\r\n\r\n# Unpack Server zip\r\nFILETYPE=$(file -F ',' ${DOWNLOAD_LINK##*\/} | cut -d',' -f2 | cut -d' ' -f2)\r\n\r\nif [ \"$FILETYPE\" == \"gzip\" ]; then\r\n    tar xzvf ${DOWNLOAD_LINK##*\/}\r\nelif [ \"$FILETYPE\" == \"Zip\" ]; then\r\n    unzip ${DOWNLOAD_LINK##*\/}\r\nelif [ \"$FILETYPE\" == \"XZ\" ]; then\r\n    tar xvf ${DOWNLOAD_LINK##*\/}\r\nelse\r\n    echo -e \"unknown filetype. Exiting\"\r\n    exit 2 \r\nfi\r\n\r\ncd \/mnt\/server\/\r\n\r\n#Create the Plugins folder\r\nmkdir plugins\/\r\n\r\n# Check for a config.json, if it is missing; create it\r\nTARGET_FILE=\"config.json\"\r\n\r\nif test -f \"$TARGET_FILE\"; then\r\n    echo \"$TARGET_FILE exists. Skipping config install\"\r\nelse\r\n    echo \"$TARGET_FILE does not exist. Installing!\"\r\n    curl -sSL -o config.json https:\/\/pteropaste.com\/hy2d48dbhtdd\/\r\n    echo \"$TARGET_FILE has been installed\"\r\nfi\r\n\r\n\r\n## Install End\r\necho \"-----------------------------------------\"\r\necho \"Hogwarp Is Installed!\"\r\necho \"-----------------------------------------\"",
+            "script": "#Hogwarp Install Script\r\n\r\napt update -y\r\napt install -y curl file unzip\r\n\r\nif [ ! -d \/mnt\/server ]; then\r\n    mkdir -p \/mnt\/server\/\r\nfi\r\n\r\ncd \/mnt\/server\/\r\nARCHIVE_NAME=\"Hogwarp.zip\"\r\n\r\n# Validate link\r\nif [ ! -z \"${DOWNLOAD_URL}\" ]; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_URL}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_URL}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_URL}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\ncurl -sSL ${DOWNLOAD_LINK} -o $ARCHIVE_NAME\r\n\r\n# Unpack Server zip\r\n# Backup and restore logic for config.json\r\nif [ -f \/mnt\/server\/config.json ]; then\r\n    mv \/mnt\/server\/config.json \/mnt\/server\/config-backup.json\r\n    unzip -o $ARCHIVE_NAME -d \/mnt\/server\r\n    rm -f \/mnt\/server\/config.json\r\n    mv \/mnt\/server\/config-backup.json \/mnt\/server\/config.json\r\nelse\r\n    unzip -o $ARCHIVE_NAME -d \/mnt\/server\r\nfi\r\n\r\n#Create the Plugins folder\r\nmkdir -p \/mnt\/server\/plugins\/\r\n\r\n\r\n## Install End\r\necho \"-----------------------------------------\"\r\necho \"Hogwarp Is Installed!\"\r\necho \"-----------------------------------------\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
     },
     "variables": [
         {
+            "sort": null,
             "name": "Wine Tricks",
             "description": "",
             "env_variable": "WINETRICKS_RUN",
-            "default_value": "dotnet7",
+            "default_value": "dotnet8",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "nullable|string",
-            "sort": null,
+            "rules": [
+                "nullable",
+                "string"
+            ],
             "field_type": "text"
         },
         {
+            "sort": null,
             "name": "Hogwarp API Key",
             "description": "A API required to boot - https:\/\/presence.hogwarp.com\/login\r\n- If not set on install it will fail. Set API Key then Reinstall Files",
             "env_variable": "API_KEY",
             "default_value": "CHANGEME",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string",
-            "sort": null,
+            "rules": [
+                "required",
+                "string"
+            ],
             "field_type": "text"
         },
         {
+            "sort": null,
             "name": "Server Name",
             "description": "A name that displays on the Hogwarp list",
             "env_variable": "SERV_NAME",
             "default_value": "Ptero Hogwarp Server",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string",
-            "sort": null,
+            "rules": [
+                "required",
+                "string"
+            ],
             "field_type": "text"
         },
         {
+            "sort": null,
             "name": "WineARCH",
             "description": "Arch type for Wine",
             "env_variable": "WINEARCH",
             "default_value": "win64",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required",
-            "sort": null,
+            "rules": [
+                "required"
+            ],
             "field_type": "text"
         },
         {
+            "sort": null,
             "name": "Max Players",
             "description": "Max players for a server, this depends on your Patreon level for Hogwarp\r\nhttps:\/\/www.patreon.com\/tiltedphoques - ( 4, 8, 16, No Limit ) In that order.",
             "env_variable": "MAX_PLAYERS",
             "default_value": "4",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|integer",
-            "sort": null,
+            "rules": [
+                "required",
+                "integer"
+            ],
             "field_type": "text"
         },
         {
+            "sort": null,
             "name": "Server Icon URL",
             "description": "The icon that displays on Hogwarps multiplayer listing",
             "env_variable": "SERV_ICON",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string",
-            "sort": null,
+            "rules": [
+                "nullable",
+                "string"
+            ],
             "field_type": "text"
         },
         {
+            "sort": null,
             "name": "Server Description",
             "description": "The description that shows on the Multiplayer list",
             "env_variable": "SERV_DESC",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string",
-            "sort": null,
+            "rules": [
+                "nullable",
+                "string"
+            ],
             "field_type": "text"
         },
         {
+            "sort": null,
             "name": "Download URL",
-            "description": "URL to pull the files from\r\n- Files can be found in their Discord (https:\/\/discord.com\/invite\/hogwarp). Default URL will pull from there as well\r\n- These files can be outdated! Be sure to check for an update in the event it has a version mismatch with the client.",
+            "description": "URL to pull the files from - By default this is blank. Files can be found in Discord!",
             "env_variable": "DOWNLOAD_URL",
-            "default_value": "https:\/\/cdn.discordapp.com\/attachments\/1076580539751993444\/1118295980597575810\/Server.zip",
+            "default_value": "",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|string",
-            "sort": null,
+            "rules": [
+                "nullable",
+                "string"
+            ],
             "field_type": "text"
         },
         {
+            "sort": null,
             "name": "WINEDEBUG",
             "description": "",
             "env_variable": "WINEDEBUG",
             "default_value": "-all",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "nullable",
-            "sort": null,
+            "rules": [
+                "nullable"
+            ],
             "field_type": "text"
         }
     ]

--- a/hogwarp/egg-pterodactyl-hogwarp.json
+++ b/hogwarp/egg-pterodactyl-hogwarp.json
@@ -4,7 +4,7 @@
         "update_url": null,
         "version": "PTDL_v2"
     },
-    "exported_at": "2024-09-07T22:35:53-04:00",
+    "exported_at": "2024-10-09T21:30:32+00:00",
     "name": "Hogwarp",
     "author": "imkringle@proton.me",
     "description": "A Pterodactyl egg for the Hogwarts Legacy mod Hogwarp - For more info see their Nexus: https://www.nexusmods.com/hogwartslegacy/mods/1378",
@@ -15,7 +15,7 @@
     "file_denylist": [],
     "startup": "export WINEDLLOVERRIDES=\"mscoree=n,b;mshtml=n,b\"; wine HogWarpServer.exe",
     "config": {
-        "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ApiKey\": \"{{env.API_KEY}}\",\r\n            \"Name\": \"{{env.SERV_NAME}}\",\r\n            \"Port\": \"{{server.build.default.port}}\",\r\n            \"Description\": \"{{env.SERV_DESC}}\",\r\n            \"MaxPlayer\": \"{{env.MAX_PLAYERS}}\",\r\n            \"IconUrl\": \"{{env.SERV_ICON}}\"\r\n        }\r\n    },\r\n    \"dotnet.runtimeconfig.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"runtimeOptions.framework.version\": \"{{env.DOTNET_VERS}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ApiKey\": \"{{env.API_KEY}}\",\r\n            \"Name\": \"{{env.SERV_NAME}}\",\r\n            \"Port\": \"{{server.build.default.port}}\",\r\n            \"Description\": \"{{env.SERV_DESC}}\",\r\n            \"MaxPlayer\": \"{{env.MAX_PLAYERS}}\",\r\n            \"IconUrl\": \"{{env.SERV_ICON}}\"\r\n        }\r\n    }\r\n}",
         "logs": "{}",
         "startup": "{\r\n    \"done\": \"Server started on port \"\r\n}",
         "stop": "^^C"
@@ -116,16 +116,6 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "nullable",
-            "field_type": "text"
-        },
-        {
-            "name": "Dotnet Version",
-            "description": "Currently Winetricks is out of date on .Net, this is a workaround",
-            "env_variable": "DOTNET_VERS",
-            "default_value": "8.0.2",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required|string",
             "field_type": "text"
         }
     ]

--- a/hogwarp/egg-pterodactyl-hogwarp.json
+++ b/hogwarp/egg-pterodactyl-hogwarp.json
@@ -1,13 +1,13 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-10-09T21:30:32+00:00",
+    "exported_at": "2024-10-20T20:24:42+02:00",
     "name": "Hogwarp",
     "author": "imkringle@proton.me",
-    "description": "A Pterodactyl egg for the Hogwarts Legacy mod Hogwarp - For more info see their Nexus: https://www.nexusmods.com/hogwartslegacy/mods/1378",
+    "description": "A Pterodactyl egg for the Hogwarts Legacy mod Hogwarp - For more info see their Nexus: https:\/\/www.nexusmods.com\/hogwartslegacy\/mods\/1378",
     "features": null,
     "docker_images": {
         "ghcr.io\/parkervcp\/yolks:wine_latest": "ghcr.io\/parkervcp\/yolks:wine_latest"
@@ -16,15 +16,15 @@
     "startup": "export WINEDLLOVERRIDES=\"mscoree=n,b;mshtml=n,b\"; wine HogWarpServer.exe",
     "config": {
         "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ApiKey\": \"{{env.API_KEY}}\",\r\n            \"Name\": \"{{env.SERV_NAME}}\",\r\n            \"Port\": \"{{server.build.default.port}}\",\r\n            \"Description\": \"{{env.SERV_DESC}}\",\r\n            \"MaxPlayer\": \"{{env.MAX_PLAYERS}}\",\r\n            \"IconUrl\": \"{{env.SERV_ICON}}\"\r\n        }\r\n    }\r\n}",
-        "logs": "{}",
         "startup": "{\r\n    \"done\": \"Server started on port \"\r\n}",
+        "logs": "{}",
         "stop": "^^C"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "bash",
             "script": "#Hogwarp Install Script\r\n\r\napt update -y\r\napt install -y curl file unzip\r\n\r\nif [ ! -d \/mnt\/server ]; then\r\n    mkdir -p \/mnt\/server\/\r\nfi\r\n\r\ncd \/mnt\/server\/\r\nARCHIVE_NAME=\"Hogwarp.zip\"\r\n\r\n# Validate link\r\nif [ ! -z \"${DOWNLOAD_URL}\" ]; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_URL}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_URL}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_URL}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\ncurl -sSL ${DOWNLOAD_LINK} -o $ARCHIVE_NAME\r\n\r\n# Unpack Server zip\r\n# Backup and restore logic for config.json\r\nif [ -f \/mnt\/server\/config.json ]; then\r\n    mv \/mnt\/server\/config.json \/mnt\/server\/config-backup.json\r\n    unzip -o $ARCHIVE_NAME -d \/mnt\/server\r\n    rm -f \/mnt\/server\/config.json\r\n    mv \/mnt\/server\/config-backup.json \/mnt\/server\/config.json\r\nelse\r\n    unzip -o $ARCHIVE_NAME -d \/mnt\/server\r\nfi\r\n\r\n#Create the Plugins folder\r\nmkdir -p \/mnt\/server\/plugins\/\r\n\r\n\r\n## Install End\r\necho \"-----------------------------------------\"\r\necho \"Hogwarp Is Installed!\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
         }
     },
     "variables": [
@@ -40,7 +40,7 @@
         },
         {
             "name": "Hogwarp API Key",
-            "description": "A API required to boot - https://presence.hogwarp.com/login\r\n- If not set on install it will fail. Set API Key then Reinstall Files",
+            "description": "A API required to boot - https:\/\/presence.hogwarp.com\/login\r\n- If not set on install it will fail. Set API Key then Reinstall Files",
             "env_variable": "API_KEY",
             "default_value": "CHANGEME",
             "user_viewable": true,
@@ -70,7 +70,7 @@
         },
         {
             "name": "Max Players",
-            "description": "Max players for a server, this depends on your Patreon level for Hogwarp\r\nhttps://www.patreon.com/tiltedphoques - ( 4, 8, 16, No Limit ) In that order.",
+            "description": "Max players for a server, this depends on your Patreon level for Hogwarp\r\nhttps:\/\/www.patreon.com\/tiltedphoques - ( 4, 8, 16, No Limit ) In that order.",
             "env_variable": "MAX_PLAYERS",
             "default_value": "4",
             "user_viewable": true,

--- a/hogwarp/egg-pterodactyl-hogwarp.json
+++ b/hogwarp/egg-pterodactyl-hogwarp.json
@@ -4,18 +4,18 @@
         "update_url": null,
         "version": "PTDL_v2"
     },
-    "exported_at": "2024-06-01T00:16:49+00:00",
+    "exported_at": "2024-09-07T22:35:53-04:00",
     "name": "Hogwarp",
     "author": "imkringle@proton.me",
     "description": "A Pterodactyl egg for the Hogwarts Legacy mod Hogwarp - For more info see their Nexus: https://www.nexusmods.com/hogwartslegacy/mods/1378",
     "features": null,
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:wine_staging": "ghcr.io/parkervcp/yolks:wine_staging"
+        "ghcr.io\/parkervcp\/yolks:wine_latest": "ghcr.io\/parkervcp\/yolks:wine_latest"
     },
     "file_denylist": [],
     "startup": "export WINEDLLOVERRIDES=\"mscoree=n,b;mshtml=n,b\"; wine HogWarpServer.exe",
     "config": {
-        "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ApiKey\": \"{{env.API_KEY}}\",\r\n            \"Name\": \"{{env.SERV_NAME}}\",\r\n            \"Port\": \"{{server.build.default.port}}\",\r\n            \"Description\": \"{{env.SERV_DESC}}\",\r\n            \"MaxPlayer\": \"{{env.MAX_PLAYERS}}\",\r\n            \"IconUrl\": \"{{env.SERV_ICON}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ApiKey\": \"{{env.API_KEY}}\",\r\n            \"Name\": \"{{env.SERV_NAME}}\",\r\n            \"Port\": \"{{server.build.default.port}}\",\r\n            \"Description\": \"{{env.SERV_DESC}}\",\r\n            \"MaxPlayer\": \"{{env.MAX_PLAYERS}}\",\r\n            \"IconUrl\": \"{{env.SERV_ICON}}\"\r\n        }\r\n    },\r\n    \"dotnet.runtimeconfig.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"runtimeOptions.framework.version\": \"{{env.DOTNET_VERS}}\"\r\n        }\r\n    }\r\n}",
         "logs": "{}",
         "startup": "{\r\n    \"done\": \"Server started on port \"\r\n}",
         "stop": "^^C"
@@ -24,7 +24,7 @@
         "installation": {
             "container": "ghcr.io/parkervcp/installers:debian",
             "entrypoint": "bash",
-            "script": "#Hogwarp Install\r\napt update -y\r\napt install -y curl file unzip\r\n\r\nif [ ! -d /mnt/server ]; then\r\n    mkdir -p /mnt/server/\r\nfi\r\n\r\ncd /mnt/server/\r\n\r\n# Validate link\r\nif [ ! -z \"${DOWNLOAD_URL}\" ]; then \r\n    if curl --output /dev/null --silent --head --fail ${DOWNLOAD_URL}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_URL}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_URL}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\ncurl -sSL ${DOWNLOAD_LINK} -o ${DOWNLOAD_LINK##*/}\r\n\r\n# Unpack Server zip\r\nFILETYPE=$(file -F ',' ${DOWNLOAD_LINK##*/} | cut -d',' -f2 | cut -d' ' -f2)\r\n\r\nif [ \"$FILETYPE\" == \"gzip\" ]; then\r\n    tar xzvf ${DOWNLOAD_LINK##*/}\r\nelif [ \"$FILETYPE\" == \"Zip\" ]; then\r\n    unzip ${DOWNLOAD_LINK##*/}\r\nelif [ \"$FILETYPE\" == \"XZ\" ]; then\r\n    tar xvf ${DOWNLOAD_LINK##*/}\r\nelse\r\n    echo -e \"unknown filetype. Exiting\"\r\n    exit 2 \r\nfi\r\n\r\ncd /mnt/server/\r\n\r\n#Create the Plugins folder\r\nmkdir plugins/\r\n\r\n# Check for a config.json, if it is missing; create it\r\nTARGET_FILE=\"config.json\"\r\n\r\nif test -f \"$TARGET_FILE\"; then\r\n    echo \"$TARGET_FILE exists. Skipping config install\"\r\nelse\r\n    echo \"$TARGET_FILE does not exist. Installing!\"\r\n    curl -sSL -o config.json https://pteropaste.com/hy2d48dbhtdd/\r\n    echo \"$TARGET_FILE has been installed\"\r\nfi\r\n\r\n\r\n## Install End\r\necho \"-----------------------------------------\"\r\necho \"Hogwarp Is Installed!\"\r\necho \"-----------------------------------------\""
+            "script": "#Hogwarp Install Script\r\n\r\napt update -y\r\napt install -y curl file unzip\r\n\r\nif [ ! -d \/mnt\/server ]; then\r\n    mkdir -p \/mnt\/server\/\r\nfi\r\n\r\ncd \/mnt\/server\/\r\nARCHIVE_NAME=\"Hogwarp.zip\"\r\n\r\n# Validate link\r\nif [ ! -z \"${DOWNLOAD_URL}\" ]; then \r\n    if curl --output \/dev\/null --silent --head --fail ${DOWNLOAD_URL}; then\r\n        echo -e \"link is valid. setting download link to ${DOWNLOAD_URL}\"\r\n        DOWNLOAD_LINK=${DOWNLOAD_URL}\r\n    else        \r\n        echo -e \"link is invalid closing out\"\r\n        exit 2\r\n    fi\r\nfi\r\n\r\ncurl -sSL ${DOWNLOAD_LINK} -o $ARCHIVE_NAME\r\n\r\n# Unpack Server zip\r\n# Backup and restore logic for config.json\r\nif [ -f \/mnt\/server\/config.json ]; then\r\n    mv \/mnt\/server\/config.json \/mnt\/server\/config-backup.json\r\n    unzip -o $ARCHIVE_NAME -d \/mnt\/server\r\n    rm -f \/mnt\/server\/config.json\r\n    mv \/mnt\/server\/config-backup.json \/mnt\/server\/config.json\r\nelse\r\n    unzip -o $ARCHIVE_NAME -d \/mnt\/server\r\nfi\r\n\r\n#Create the Plugins folder\r\nmkdir -p \/mnt\/server\/plugins\/\r\n\r\n\r\n## Install End\r\necho \"-----------------------------------------\"\r\necho \"Hogwarp Is Installed!\"\r\necho \"-----------------------------------------\"",
         }
     },
     "variables": [
@@ -32,7 +32,7 @@
             "name": "Wine Tricks",
             "description": "",
             "env_variable": "WINETRICKS_RUN",
-            "default_value": "dotnet7",
+            "default_value": "dotnet8",
             "user_viewable": false,
             "user_editable": false,
             "rules": "nullable|string",
@@ -100,12 +100,12 @@
         },
         {
             "name": "Download URL",
-            "description": "URL to pull the files from\r\n- Files can be found in their Discord (https://discord.com/invite/hogwarp). Default URL will pull from there as well\r\n- These files can be outdated! Be sure to check for an update in the event it has a version mismatch with the client.",
+            "description": "URL to pull the files from - By default this is blank. Files can be found in Discord!",
             "env_variable": "DOWNLOAD_URL",
-            "default_value": "https://cdn.discordapp.com/attachments/1076580539751993444/1118295980597575810/Server.zip",
+            "default_value": "",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|string",
+            "rules": "nullable|string",
             "field_type": "text"
         },
         {
@@ -116,6 +116,16 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "nullable",
+            "field_type": "text"
+        },
+        {
+            "name": "Dotnet Version",
+            "description": "Currently Winetricks is out of date on .Net, this is a workaround",
+            "env_variable": "DOTNET_VERS",
+            "default_value": "8.0.2",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
# Description

Hogwarp has received a new update, meaning this set of files is out of date
- Discord DOWNLOAD_URL times out quite fast, this has been removed and is just a optional method to use the Install script; otherwise files need manually uploaded (They are only in their Discord)
- Dotnet requirement has gone to 8.0.6, as Tricks only uses 8.0.2 currently the dotnet config is edited to resolve a crash; this does not affect any functionality after testing
- Wine has been changed to Wine-Latest

I do not have Pelican, so I cannot update the egg for that panel; if someone with it installed could and edit this PR 👍🏼 

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel