### PR TITLE
[Other] Fix broken author links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,7 +10,7 @@ body:
         * `A fatal error was encountered while starting this server.`
         * `No server egg configuration could be located; aborting startup.`
 
-        Make sure there are no existing bug reports by searching the [repository issues](https://github.com/parkervcp/eggs/issues?q=is%3Aopen+is%3Aissue+label%3ABug).
+        Make sure there are no existing bug reports by searching the [repository issues](https://github.com/pelican-eggs/games-standalone/issues?q=is%3Aopen+is%3Aissue+label%3ABug).
   - type: input
     id: panel-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/egg-request.yml
+++ b/.github/ISSUE_TEMPLATE/egg-request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-          Make sure there are no existing egg requests by searching the [repository issues](https://github.com/parkervcp/eggs/labels/egg%20request). Please understand how Pterodactyl works when you are requesting an egg. (ie. docker-compose doesn't work for a pterodactyl server)
+          Make sure there are no existing egg requests by searching the [repository issues](https://github.com/pelican-eggs/games-standalone/labels/egg%20request). Please understand how Pterodactyl works when you are requesting an egg. (ie. docker-compose doesn't work for a pterodactyl server)
   - type: dropdown
     id: expand
     attributes:

--- a/.github/ISSUE_TEMPLATE/install-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/install-bug-report.yml
@@ -10,7 +10,7 @@ body:
         * `A fatal error was encountered while starting this server.`
         * `No server egg configuration could be located; aborting startup.`
 
-        Make sure there are no existing bug reports by searching the the issues for [install bugs](https://github.com/parkervcp/eggs/labels/install%20bug).
+        Make sure there are no existing bug reports by searching the the issues for [install bugs](https://github.com/pelican-eggs/games-standalone/labels/install%20bug).
   - type: input
     id: panel-version
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 <!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->
 
-* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
+* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-standalone/blob/master/CONTRIBUTING.md)?
 * [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
 * [ ] Have you tested and reviewed your changes with confidence that everything works?
 * [ ] Did you branch your changes and PR from that branch and not from your master branch?

--- a/openrct2/README.md
+++ b/openrct2/README.md
@@ -7,12 +7,12 @@
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Maintains">🔨</a>
+            <a href="https://github.com/parkervcp/eggs/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/parkervcp/eggs/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/parkervcp">

--- a/openrct2/README.md
+++ b/openrct2/README.md
@@ -11,16 +11,16 @@
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=redthirten" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=redthirten" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-standalone/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-standalone/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/parkervcp">
                 <img src="https://avatars.githubusercontent.com/u/1207679" width="50px;" alt=""/><br /><sub><b>parkervcp</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=parkervcp" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=parkervcp" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-standalone/commits?author=parkervcp" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-standalone/commits?author=parkervcp" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/janisozaur">


### PR DESCRIPTION
# Description

I changed my Github username a while back and assumed the links would auto-forward, but unfortunately they do not. This PR corrects all of my author Github links across the repository. This also corrects any `parkervcp/eggs` links with `pelican-eggs/games-standalone`.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?