### PR TITLE
fix(terraria): tshock world name

### DIFF
--- a/terraria/tshock/egg-pterodactyl-tshock.json
+++ b/terraria/tshock/egg-pterodactyl-tshock.json
@@ -65,7 +65,7 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": false,
-            "rules": "required|string|max:20",
+            "rules": "required|string|alpha_dash|max:20",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
# Description
Tshock bugs and creates a new world at every restart with a number at the end, whenever the world inserted by the panel contains a space. The old world is not affected, but several .wld files are generated.

![image](https://github.com/user-attachments/assets/43b37de6-46f3-4302-af10-f596c269a4c9)


## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
