### PR TITLE
Update Vintage Story to support version starting at 1.21.0 using dotnet 8

### DIFF
--- a/vintage_story/README.md
+++ b/vintage_story/README.md
@@ -20,3 +20,8 @@ Vintage Story requires a single port
 | Port    | default |
 |---------|---------|
 | Game    | 42420   |
+
+
+## Docker Image Configuration
+
+When you install a version greater or equal to 1.21.0 you will need to select the `Dotnet 8` Docker Image in the `Startup` section.

--- a/vintage_story/egg-pterodactyl-vintage-story.json
+++ b/vintage_story/egg-pterodactyl-vintage-story.json
@@ -1,30 +1,31 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T00:17:19+00:00",
+    "exported_at": "2025-08-01T06:02:46-04:00",
     "name": "Vintage Story",
     "author": "mail@wuffy.eu",
     "description": "Vintage Story is an uncompromising wilderness survival sandbox game inspired by lovecraftian horror themes. Find yourself in a ruined world reclaimed by nature and permeated by unnerving temporal disturbances. Relive the advent of human civilization, or take your own path.",
     "features": null,
     "docker_images": {
-        "Dotnet 7": "ghcr.io/parkervcp/yolks:dotnet_7"
+        "Dotnet 7": "ghcr.io\/parkervcp\/yolks:dotnet_7",
+        "Dotnet 8": "ghcr.io\/parkervcp\/yolks:dotnet_8"
     },
     "file_denylist": [],
-    "startup": "./VintagestoryServer --dataPath ./data --port={{SERVER_PORT}} --maxclients={{MAX_CLIENTS}} {{OPTIONS}}",
+    "startup": ".\/VintagestoryServer --dataPath .\/data --port={{SERVER_PORT}} --maxclients={{MAX_CLIENTS}} {{OPTIONS}}",
     "config": {
         "files": "{}",
-        "logs": "{}",
         "startup": "{\r\n    \"done\": \"Dedicated Server now running on Port \"\r\n}",
-        "stop": "/stop"
+        "logs": "{}",
+        "stop": "\/stop"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "bash",
-            "script": "#!/bin/bash\r\n# Vintage Story Installation Script\r\n#\r\n# Server Files: /mnt/server\r\napt update\r\napt -y install curl jq\r\n\r\ndeclare -A API_URLS=(\r\n  [\"stable\"]=\"http://api.vintagestory.at/stable.json\"\r\n  [\"unstable\"]=\"http://api.vintagestory.at/unstable.json\"\r\n)\r\n\r\ndeclare -A DOWNLOAD_URLS=(\r\n  [\"stable\"]=\"https://cdn.vintagestory.at/gamefiles/stable/vs_server_linux-x64_${RELEASE_VERSION}.tar.gz\"\r\n  [\"unstable\"]=\"https://cdn.vintagestory.at/gamefiles/unstable/vs_server_linux-x64_${RELEASE_VERSION}.tar.gz\"\r\n  [\"pre\"]=\"https://cdn.vintagestory.at/gamefiles/pre/vs_server_linux-x64_${RELEASE_VERSION}.tar.gz\"\r\n)\r\n\r\nBRANCH=\"${FILES_BRANCH}\"\r\n\r\nif [ -z \"${RELEASE_VERSION}\" ] || [ \"${RELEASE_VERSION}\" == \"latest\" ] \u0026\u0026 [ \"${BRANCH}\" == \"pre\" ]; then\r\n  echo \"-----------------------------------------\"\r\n  echo \"Installation failed...\"\r\n  echo \"Please specify the version when using RELEASE BRANCH: pre\"\r\n  echo \"-----------------------------------------\"  \r\n  exit\r\nfi\r\n\r\nif [ -z \"${RELEASE_VERSION}\" ] || [ \"${RELEASE_VERSION}\" == \"latest\" ]; then\r\n  API_URL=\"${API_URLS[$BRANCH]}\"\r\n  echo \"API URL: $API_URL\"\r\n  DOWNLOAD_URL=$(curl -SsL \"$API_URL\" | jq -r 'if ([.[]] | .[0].linuxserver.urls.cdn) != null then [.[]] | .[0].linuxserver.urls.cdn else [.[]] | .[0].linuxserver.urls.local end')\r\nelse\r\n  DOWNLOAD_URL=\"${DOWNLOAD_URLS[$BRANCH]}\"\r\nfi\r\n\r\necho \"Download URL: $DOWNLOAD_URL\"\r\n\r\ncd /mnt/server/ || exit\r\n\r\n# make sure to cleanup the prior installation else this might cause issue with old asset files that do not exist in the new version\r\nif [ -d \"assets\" ]; then\r\n  echo \"Removing old installation files\"\r\n  rm -rf assets/\r\n  rm -rf Lib/\r\nfi\r\ncurl -o vs_server.tar.gz \"${DOWNLOAD_URL}\"\r\ntar -xzf vs_server.tar.gz\r\n\r\nif [ $? -ne 0 ]; then\r\n  echo \"-----------------------------------------\"\r\n  echo \"Installation failed...\"\r\n  echo \"Please make sure the specified version exists: $RELEASE_VERSION\"\r\n  echo \"-----------------------------------------\"\r\n  rm vs_server.tar.gz\r\n  exit\r\nfi\r\n\r\nrm vs_server.tar.gz\r\nrm server.sh\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\""
+            "script": "#!\/bin\/bash\r\n# Vintage Story Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt update\r\napt -y install curl jq\r\n\r\ndeclare -A API_URLS=(\r\n  [\"stable\"]=\"http:\/\/api.vintagestory.at\/stable.json\"\r\n  [\"unstable\"]=\"http:\/\/api.vintagestory.at\/unstable.json\"\r\n)\r\n\r\ndeclare -A DOWNLOAD_URLS=(\r\n  [\"stable\"]=\"https:\/\/cdn.vintagestory.at\/gamefiles\/stable\/vs_server_linux-x64_${RELEASE_VERSION}.tar.gz\"\r\n  [\"unstable\"]=\"https:\/\/cdn.vintagestory.at\/gamefiles\/unstable\/vs_server_linux-x64_${RELEASE_VERSION}.tar.gz\"\r\n  [\"pre\"]=\"https:\/\/cdn.vintagestory.at\/gamefiles\/pre\/vs_server_linux-x64_${RELEASE_VERSION}.tar.gz\"\r\n)\r\n\r\nBRANCH=\"${FILES_BRANCH}\"\r\n\r\nif [ -z \"${RELEASE_VERSION}\" ] || [ \"${RELEASE_VERSION}\" == \"latest\" ] && [ \"${BRANCH}\" == \"pre\" ]; then\r\n  echo \"-----------------------------------------\"\r\n  echo \"Installation failed...\"\r\n  echo \"Please specify the version when using RELEASE BRANCH: pre\"\r\n  echo \"-----------------------------------------\"  \r\n  exit\r\nfi\r\n\r\nif [ -z \"${RELEASE_VERSION}\" ] || [ \"${RELEASE_VERSION}\" == \"latest\" ]; then\r\n  API_URL=\"${API_URLS[$BRANCH]}\"\r\n  echo \"API URL: $API_URL\"\r\n  DOWNLOAD_URL=$(curl -SsL \"$API_URL\" | jq -r 'if ([.[]] | .[0].linuxserver.urls.cdn) != null then [.[]] | .[0].linuxserver.urls.cdn else [.[]] | .[0].linuxserver.urls.local end')\r\nelse\r\n  DOWNLOAD_URL=\"${DOWNLOAD_URLS[$BRANCH]}\"\r\nfi\r\n\r\necho \"Download URL: $DOWNLOAD_URL\"\r\n\r\ncd \/mnt\/server\/ || exit\r\n\r\n# make sure to cleanup the prior installation else this might cause issue with old asset files that do not exist in the new version\r\nif [ -d \"assets\" ]; then\r\n  echo \"Removing old installation files\"\r\n  rm -rf assets\/\r\n  rm -rf Lib\/\r\nfi\r\ncurl -o vs_server.tar.gz \"${DOWNLOAD_URL}\"\r\ntar -xzf vs_server.tar.gz\r\n\r\nif [ $? -ne 0 ]; then\r\n  echo \"-----------------------------------------\"\r\n  echo \"Installation failed...\"\r\n  echo \"Please make sure the specified version exists: $RELEASE_VERSION\"\r\n  echo \"-----------------------------------------\"\r\n  rm vs_server.tar.gz\r\n  exit\r\nfi\r\n\r\nrm vs_server.tar.gz\r\nrm server.sh\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
         }
     },
     "variables": [
@@ -70,9 +71,9 @@
         },
         {
             "name": "Sqlite temporary files directory",
-            "description": "Defines the location for the temporary files in sqlite. This is needed for the \"/db vacuum\" command (added in 1.19) since else it will use the /tmp folder which by default only has 100MB and is in memory.",
+            "description": "Defines the location for the temporary files in sqlite. This is needed for the \"\/db vacuum\" command (added in 1.19) since else it will use the \/tmp folder which by default only has 100MB and is in memory.",
             "env_variable": "SQLITE_TMPDIR",
-            "default_value": "/home/container/data/Backups",
+            "default_value": "\/home\/container\/data\/Backups",
             "user_viewable": true,
             "user_editable": false,
             "rules": "required|string|max:40",

--- a/vintage_story/egg-vintage-story.json
+++ b/vintage_story/egg-vintage-story.json
@@ -1,17 +1,19 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:17:19+00:00",
+    "exported_at": "2025-08-01T10:17:52+00:00",
     "name": "Vintage Story",
     "author": "mail@wuffy.eu",
     "uuid": "270ab8c0-d108-4c05-a362-62d81e8063a5",
     "description": "Vintage Story is an uncompromising wilderness survival sandbox game inspired by lovecraftian horror themes. Find yourself in a ruined world reclaimed by nature and permeated by unnerving temporal disturbances. Relive the advent of human civilization, or take your own path.",
-    "features": null,
+    "tags": [],
+    "features": [],
     "docker_images": {
-        "Dotnet 7": "ghcr.io\/parkervcp\/yolks:dotnet_7"
+        "Dotnet 7": "ghcr.io\/parkervcp\/yolks:dotnet_7",
+        "Dotnet 8": "ghcr.io\/parkervcp\/yolks:dotnet_8"
     },
     "file_denylist": [],
     "startup": ".\/VintagestoryServer --dataPath .\/data --port={{SERVER_PORT}} --maxclients={{MAX_CLIENTS}} {{OPTIONS}}",
@@ -36,9 +38,12 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|max:200",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "nullable",
+                "string",
+                "max:200"
+            ],
+            "sort": 1
         },
         {
             "name": "Release branch",
@@ -47,9 +52,12 @@
             "default_value": "stable",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:stable,unstable,pre",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "in:stable,unstable,pre"
+            ],
+            "sort": 2
         },
         {
             "name": "Release version",
@@ -58,9 +66,12 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:20"
+            ],
+            "sort": 3
         },
         {
             "name": "Max Clients",
@@ -69,9 +80,12 @@
             "default_value": "16",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|integer|max:256",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "integer",
+                "max:256"
+            ],
+            "sort": 4
         },
         {
             "name": "Sqlite temporary files directory",
@@ -80,9 +94,12 @@
             "default_value": "\/home\/container\/data\/Backups",
             "user_viewable": true,
             "user_editable": false,
-            "rules": "required|string|max:40",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:40"
+            ],
+            "sort": 5
         }
     ]
 }


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->
Added the docker dotnet 8 image as an option in the drop down of container images for the newer game version 1.21.0 and above

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-standalone/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

The Pterodactyl egg was imported from this repo into my own Ptrodactyl instance (Panel v 1.11.11)  then modified and exported afterwards. Note that the export now added a some escape `\` for special characters, those where not added by hand.

I did also import the pelican one (without pterodactyl in the name) into the https://demo.pelican.dev/ instance to modify it and then export it from there again. Note there are also some format changes and fields changed/removed.

I did test the Pterodactyl one that it works, but I could not test the pelican one since the websocket could not connect. If the field changes wont cause any issues it should be good to go.