### PR TITLE
Update egg-vintage-story.json

### DIFF
--- a/vintage_story/egg-vintage-story.json
+++ b/vintage_story/egg-vintage-story.json
@@ -11,7 +11,8 @@
     "description": "Vintage Story is an uncompromising wilderness survival sandbox game inspired by lovecraftian horror themes. Find yourself in a ruined world reclaimed by nature and permeated by unnerving temporal disturbances. Relive the advent of human civilization, or take your own path.",
     "features": null,
     "docker_images": {
-        "Dotnet 7": "ghcr.io\/parkervcp\/yolks:dotnet_7"
+        "Dotnet 7": "ghcr.io\/parkervcp\/yolks:dotnet_7" 
+        "Dotnet 8": "ghcr.io\/parkervcp\/yolks:dotnet_8"
     },
     "file_denylist": [],
     "startup": ".\/VintagestoryServer --dataPath .\/data --port={{SERVER_PORT}} --maxclients={{MAX_CLIENTS}} {{OPTIONS}}",


### PR DESCRIPTION
v1.21 now needs .net 8

# Description

Added .net 8 because newer version need it


<!-- If this is an egg update fill these out -->

* [x ] You verify that the start command applied does not use a shell script
  * [ x] If some script is needed then it is part of a current yolk or a PR to add one
* [ x] The egg was exported from the panel


