### PR TITLE
Update Veloren to Ubuntu

### DIFF
--- a/veloren/egg-pterodactyl-veloren.json
+++ b/veloren/egg-pterodactyl-veloren.json
@@ -1,30 +1,30 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T00:17:20+00:00",
+    "exported_at": "2025-10-19T18:43:29+02:00",
     "name": "Veloren",
     "author": "parker@parkervcp.com",
     "description": "Veloren is a multiplayer voxel RPG written in Rust. It is inspired by games such as Cube World, Legend of Zelda: Breath of the Wild, Dwarf Fortress and Minecraft.",
     "features": null,
     "docker_images": {
-        "Debian": "ghcr.io/parkervcp/yolks:debian"
+        "Ubuntu": "ghcr.io\/pelican-eggs\/yolks:ubuntu"
     },
     "file_denylist": [],
-    "startup": "./veloren-server-cli",
+    "startup": ".\/veloren-server-cli",
     "config": {
-        "files": "{\r\n    \"userdata/server/server_config/settings.ron\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"    metrics_address\": \"    metrics_address: \\\"0.0.0.0:{{server.build.env.METRICS_PORT}}\\\",\",\r\n            \"    server_name\": \"    server_name: \\\"{{server.build.env.SERVER_NAME}}\\\",\"\r\n        }\r\n    }\r\n}",
-        "logs": "{}",
+        "files": "{\r\n    \"userdata\/server\/server_config\/settings.ron\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"    metrics_address\": \"    metrics_address: \\\"0.0.0.0:{{server.build.env.METRICS_PORT}}\\\",\",\r\n            \"    server_name\": \"    server_name: \\\"{{server.build.env.SERVER_NAME}}\\\",\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server is ready to accept connections\"\r\n}",
+        "logs": "{}",
         "stop": "shutdown graceful 10"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "bash",
-            "script": "#!/bin/bash\r\n\r\napt update\r\napt install -y curl wget unzip git jq\r\n\r\nmkdir -p /mnt/server\r\ncd /mnt/server\r\n\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] \u0026\u0026 echo \"x86_64\" || echo \"aarch64\")\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"weekly\" ]; then\r\n    echo -e \"weekly\"\r\n    DOWNLOAD_URL=https://download.veloren.net/latest/linux/${ARCH}/weekly\r\nelif [ \"${VERSION}\" == \"nightly\" ]; then\r\n    echo -e \"nightly\"\r\n    DOWNLOAD_URL=https://download.veloren.net/latest/linux/${ARCH}/nightly\r\nelse\r\n    echo -e  \"something went wrong\"\r\nfi\r\n\r\necho -e \"download url: ${DOWNLOAD_URL}\"\r\nwget ${DOWNLOAD_URL} -O files.zip\r\n\r\nunzip -o files.zip\r\nrm files.zip\r\n\r\nchmod +x veloren-server-cli\r\n\r\n## generate config because there is no better way to get it.\r\nmkdir -p /mnt/server/userdata/server/server_config/\r\nif [ ! -f /mnt/server/userdata/server/server_config/settings.ron ]; then\r\n    wget https://raw.githubusercontent.com/parkervcp/eggs/master/game_eggs/veloren/settings.ron -O /tmp/settings.ron\r\n    sed \"s/14004/${SERVER_PORT}/g\" /tmp/settings.ron \u003e /mnt/server/userdata/server/server_config/settings.ron\r\n    rm /tmp/settings.ron\r\n    echo \"config file pulled\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\""
+            "script": "#!\/bin\/bash\r\n\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"x86_64\" || echo \"aarch64\")\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"weekly\" ]; then\r\n    echo -e \"weekly\"\r\n    DOWNLOAD_URL=https:\/\/download.veloren.net\/latest\/linux\/${ARCH}\/weekly\r\nelif [ \"${VERSION}\" == \"nightly\" ]; then\r\n    echo -e \"nightly\"\r\n    DOWNLOAD_URL=https:\/\/download.veloren.net\/latest\/linux\/${ARCH}\/nightly\r\nelse\r\n    echo -e  \"something went wrong\"\r\nfi\r\n\r\necho -e \"download url: ${DOWNLOAD_URL}\"\r\nwget ${DOWNLOAD_URL} -O files.zip\r\n\r\nunzip -o files.zip\r\nrm files.zip\r\n\r\nchmod +x veloren-server-cli\r\n\r\n## generate config because there is no better way to get it.\r\nmkdir -p \/mnt\/server\/userdata\/server\/server_config\/\r\nif [ ! -f \/mnt\/server\/userdata\/server\/server_config\/settings.ron ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/pelican-eggs\/games-standalone\/refs\/heads\/main\/veloren\/settings.ron -O \/tmp\/settings.ron\r\n    sed \"s\/14004\/${SERVER_PORT}\/g\" \/tmp\/settings.ron > \/mnt\/server\/userdata\/server\/server_config\/settings.ron\r\n    rm \/tmp\/settings.ron\r\n    echo \"config file pulled\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/pelican-eggs\/installers:debian",
+            "entrypoint": "bash"
         }
     },
     "variables": [

--- a/veloren/egg-veloren.json
+++ b/veloren/egg-veloren.json
@@ -1,30 +1,30 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
-        "update_url": null
+        "version": "PLCN_v1",
+        "update_url": "https:\/\/raw.githubusercontent.com\/pelican-eggs\/games-standalone\/refs\/heads\/main\/veloren\/egg-veloren.json"
     },
-    "exported_at": "2024-06-01T00:17:20+00:00",
+    "exported_at": "2025-10-19T18:43:29+02:00",
     "name": "Veloren",
     "author": "parker@parkervcp.com",
     "uuid": "3b814b4e-a86d-4eca-ad00-1cdfe4a2baca",
     "description": "Veloren is a multiplayer voxel RPG written in Rust. It is inspired by games such as Cube World, Legend of Zelda: Breath of the Wild, Dwarf Fortress and Minecraft.",
     "features": null,
     "docker_images": {
-        "Debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "Ubuntu": "ghcr.io\/pelican-eggs\/yolks:ubuntu"
     },
     "file_denylist": [],
     "startup": ".\/veloren-server-cli",
     "config": {
-        "files": "{\r\n    \"userdata\/server\/server_config\/settings.ron\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"    metrics_address\": \"    metrics_address: \\\"0.0.0.0:{{server.build.env.METRICS_PORT}}\\\",\",\r\n            \"    server_name\": \"    server_name: \\\"{{server.build.env.SERVER_NAME}}\\\",\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"userdata\/server\/server_config\/settings.ron\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"    metrics_address\": \"    metrics_address: \\\"0.0.0.0:{{server.environment.METRICS_PORT}}\\\",\",\r\n            \"    server_name\": \"    server_name: \\\"{{server.environment.SERVER_NAME}}\\\",\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server is ready to accept connections\"\r\n}",
         "logs": "{}",
         "stop": "shutdown graceful 10"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\napt update\r\napt install -y curl wget unzip git jq\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"x86_64\" || echo \"aarch64\")\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"weekly\" ]; then\r\n    echo -e \"weekly\"\r\n    DOWNLOAD_URL=https:\/\/download.veloren.net\/latest\/linux\/${ARCH}\/weekly\r\nelif [ \"${VERSION}\" == \"nightly\" ]; then\r\n    echo -e \"nightly\"\r\n    DOWNLOAD_URL=https:\/\/download.veloren.net\/latest\/linux\/${ARCH}\/nightly\r\nelse\r\n    echo -e  \"something went wrong\"\r\nfi\r\n\r\necho -e \"download url: ${DOWNLOAD_URL}\"\r\nwget ${DOWNLOAD_URL} -O files.zip\r\n\r\nunzip -o files.zip\r\nrm files.zip\r\n\r\nchmod +x veloren-server-cli\r\n\r\n## generate config because there is no better way to get it.\r\nmkdir -p \/mnt\/server\/userdata\/server\/server_config\/\r\nif [ ! -f \/mnt\/server\/userdata\/server\/server_config\/settings.ron ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/parkervcp\/eggs\/master\/game_eggs\/veloren\/settings.ron -O \/tmp\/settings.ron\r\n    sed \"s\/14004\/${SERVER_PORT}\/g\" \/tmp\/settings.ron > \/mnt\/server\/userdata\/server\/server_config\/settings.ron\r\n    rm \/tmp\/settings.ron\r\n    echo \"config file pulled\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
-            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "script": "#!\/bin\/bash\r\n\r\n\r\nmkdir -p \/mnt\/server\r\ncd \/mnt\/server\r\n\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"x86_64\" || echo \"aarch64\")\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"weekly\" ]; then\r\n    echo -e \"weekly\"\r\n    DOWNLOAD_URL=https:\/\/download.veloren.net\/latest\/linux\/${ARCH}\/weekly\r\nelif [ \"${VERSION}\" == \"nightly\" ]; then\r\n    echo -e \"nightly\"\r\n    DOWNLOAD_URL=https:\/\/download.veloren.net\/latest\/linux\/${ARCH}\/nightly\r\nelse\r\n    echo -e  \"something went wrong\"\r\nfi\r\n\r\necho -e \"download url: ${DOWNLOAD_URL}\"\r\nwget ${DOWNLOAD_URL} -O files.zip\r\n\r\nunzip -o files.zip\r\nrm files.zip\r\n\r\nchmod +x veloren-server-cli\r\n\r\n## generate config because there is no better way to get it.\r\nmkdir -p \/mnt\/server\/userdata\/server\/server_config\/\r\nif [ ! -f \/mnt\/server\/userdata\/server\/server_config\/settings.ron ]; then\r\n    wget https:\/\/raw.githubusercontent.com\/pelican-eggs\/games-standalone\/refs\/heads\/main\/veloren\/settings.ron -O \/tmp\/settings.ron\r\n    sed \"s\/14004\/${SERVER_PORT}\/g\" \/tmp\/settings.ron > \/mnt\/server\/userdata\/server\/server_config\/settings.ron\r\n    rm \/tmp\/settings.ron\r\n    echo \"config file pulled\"\r\nfi\r\n\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/pelican-eggs\/installers:debian",
             "entrypoint": "bash"
         }
     },
@@ -36,9 +36,12 @@
             "default_value": "weekly",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:weekly,nightly",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "in:weekly,nightly"
+            ],
+            "sort": 1
         },
         {
             "name": "Server name",
@@ -47,9 +50,12 @@
             "default_value": "A pterodactyl hosted server",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:64",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:64"
+            ],
+            "sort": 2
         },
         {
             "name": "Metrics port",
@@ -58,9 +64,11 @@
             "default_value": "14005",
             "user_viewable": true,
             "user_editable": false,
-            "rules": "required|integer",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "integer"
+            ],
+            "sort": 3
         }
     ]
 }


### PR DESCRIPTION
# Description

- /veloren-server-cli: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./veloren-server-cli)

this version is not in debian 12 so switch to ubuntu what is using 24.04
- Remove unneeded apt install from install cmd

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-standalone/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel
