### PR TITLE
Update Super Tux Kart egg

### DIFF
--- a/SuperTuxKart/egg-super-tux-kart.json
+++ b/SuperTuxKart/egg-super-tux-kart.json
@@ -1,45 +1,38 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v3",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:17:12+00:00",
+    "exported_at": "2026-01-25T15:15:37+00:00",
     "name": "SuperTuxKart",
     "author": "mattamn107@github.com",
     "uuid": "9eec81aa-b165-4233-aa30-1244c6c96e9f",
     "description": "Egg for hosting a SuperTuxKart Server.",
-    "features": null,
+    "image": null,
+    "tags": [],
+    "features": [],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "ghcr.io/parkervcp/yolks:debian": "ghcr.io/parkervcp/yolks:debian"
     },
     "file_denylist": [],
-    "startup": ".\/bin\/supertuxkart --server-config={{CONFIG_NAME}} --lan-server={{SERVER_NAME}} --network-console --port=\"{{SERVER_PORT}}\" --difficulty={{DIFFICULTY}} --mode={{MODE}} --max-players={{MAX_PLAYERS}} --motd=\"{{MOTD}}\"",
+    "startup_commands": {
+        "Default": "./bin/supertuxkart --server-config={{CONFIG_NAME}} --lan-server={{SERVER_NAME}} --network-console --port=\"{{SERVER_PORT}}\" --difficulty={{DIFFICULTY}} --mode={{MODE}} --max-players={{MAX_PLAYERS}} --motd=\"{{MOTD}}\""
+    },
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Available command:\"\r\n}",
+        "startup": "{\n    \"done\": \"Available command:\"\n}",
         "logs": "{}",
         "stop": "quit"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\n# Install build tools\r\necho \"deb http:\/\/deb.debian.org\/debian bullseye-backports main\" >> \/etc\/apt\/sources.list && \\\r\napt-get update && apt-get -y full-upgrade && \\\r\n    apt-get install -y build-essential cmake libbluetooth-dev libsdl2-dev \\\r\n    libcurl4-openssl-dev libenet-dev libfreetype6-dev libharfbuzz-dev \\\r\n    libjpeg-dev libogg-dev libopenal-dev libpng-dev \\\r\n    libssl-dev libvorbis-dev libmbedtls-dev pkg-config zlib1g-dev subversion\r\n\r\nif [ ! -d \"\/mnt\/server\/stk-code\" ] && [ ! -d \"\/mnt\/server\/stk-assets\" ]; then\r\n    \r\n    #clone code repo\r\n    git clone https:\/\/github.com\/supertuxkart\/stk-code \/mnt\/server\/stk-code\r\n    \r\n    #get assets\r\n    svn co https:\/\/svn.code.sf.net\/p\/supertuxkart\/code\/stk-assets \/mnt\/server\/stk-assets\r\n    \r\n    # go into the stk-code directory\r\n    cd \/mnt\/server\/stk-code\r\n    \r\n    # create and enter the cmake_build directory\r\n    mkdir cmake_build\r\n    \r\nelse\r\n\r\n    #update existing stuff\r\n    cd \/mnt\/server\/stk-assets\r\n    svn up\r\n    \r\n    cd \/mnt\/server\/stk-code\r\n    git pull\r\n\r\n\r\nfi\r\n\r\n#build the server\r\ncd cmake_build\r\ncmake .. -DSERVER_ONLY=ON\r\nmake\r\n\r\n#copy binary to root\/bin and make it executable\r\nmkdir \/mnt\/server\/bin\r\ncp \/mnt\/server\/stk-code\/cmake_build\/bin\/supertuxkart \/mnt\/server\/bin\/supertuxkart\r\nchmod +x \/mnt\/server\/bin\/supertuxkart\r\n\r\n#copy data folder\r\ncp -r \/mnt\/server\/stk-code\/data \/mnt\/server\/data\r\n\r\n#copy extra assets to data folder\r\ncd \/mnt\/server\/stk-assets\r\ncp -r library models music sfx textures tracks karts \/mnt\/server\/data\/\r\n\r\n# Delete repo's to save disk space.\r\n#rm -rf \/mnt\/server\/stk-code && rm -rf \/mnt\/server\/stk-assets",
-            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "script": "#!/bin/bash\r\n\r\n# Install build tools\r\necho \"deb http://deb.debian.org/debian bookworm-backports main\" >> /etc/apt/sources.list && \\\r\napt-get update && apt-get -y full-upgrade && \\\r\n    apt-get install -y build-essential cmake libbluetooth-dev libsdl2-dev \\\r\n    libcurl4-openssl-dev libenet-dev libfreetype6-dev libharfbuzz-dev \\\r\n    libjpeg-dev libogg-dev libopenal-dev libpng-dev \\\r\n    libssl-dev libvorbis-dev libmbedtls-dev pkg-config zlib1g-dev subversion\r\n\r\nif [ ! -d \"/mnt/server/stk-code\" ] || [ ! -d \"/mnt/server/stk-assets\" ]; then\r\n    \r\n    #clone code repo\r\n    git clone https://github.com/supertuxkart/stk-code /mnt/server/stk-code\r\n    \r\n    #get assets\r\n    svn co https://svn.code.sf.net/p/supertuxkart/code/stk-assets /mnt/server/stk-assets\r\n    \r\n    # go into the stk-code directory\r\n    cd /mnt/server/stk-code\r\n    \r\n    # create and enter the cmake_build directory\r\n    mkdir cmake_build\r\n    \r\nelse\r\n\r\n    #update existing stuff\r\n    cd /mnt/server/stk-assets\r\n    svn up\r\n    \r\n    cd /mnt/server/stk-code\r\n    git pull\r\n\r\n\r\nfi\r\n\r\n#build the server\r\ncd cmake_build\r\ncmake .. -DSERVER_ONLY=ON\r\nmake\r\n\r\n#copy binary to root/bin and make it executable\r\nmkdir /mnt/server/bin\r\ncp /mnt/server/stk-code/cmake_build/bin/supertuxkart /mnt/server/bin/supertuxkart\r\nchmod +x /mnt/server/bin/supertuxkart\r\n\r\n#copy data folder\r\ncp -r /mnt/server/stk-code/data /mnt/server/data\r\n\r\n#copy extra assets to data folder\r\ncd /mnt/server/stk-assets\r\ncp -r library models music sfx textures tracks karts /mnt/server/data/\r\n\r\n# Delete repo's to save disk space.\r\n#rm -rf /mnt/server/stk-code && rm -rf /mnt/server/stk-assets",
+            "container": "ghcr.io/parkervcp/installers:debian",
             "entrypoint": "bash"
         }
     },
     "variables": [
-        {
-            "name": "Server Name",
-            "description": "The Name of the Server",
-            "env_variable": "SERVER_NAME",
-            "default_value": "Pterodactyl_Server",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|max:50",
-            "sort": null,
-            "field_type": "text"
-        },
         {
             "name": "Config File Name",
             "description": "Name of the Config File.",
@@ -47,20 +40,11 @@
             "default_value": "config.xml",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.xml)$\/",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Mode",
-            "description": "0 = Normal Race\r\n1 = Time Trial\r\n2 = Battle\r\n3 = Soccer\r\n4 = Follow The Leader\r\n5 = Capture the Flag",
-            "env_variable": "MODE",
-            "default_value": "0",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|in:0,1,2,3,4,5",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "regex:/^([\\w\\d._-]+)(\\.xml)$/"
+            ],
+            "sort": 1
         },
         {
             "name": "Difficulty",
@@ -69,9 +53,12 @@
             "default_value": "0",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:0,1,2,3",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "in:0,1,2,3"
+            ],
+            "sort": 2
         },
         {
             "name": "Max Players",
@@ -80,9 +67,12 @@
             "default_value": "8",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|numeric|between:1,24",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "numeric",
+                "between:1,24"
+            ],
+            "sort": 3
         },
         {
             "name": "Message of the Day",
@@ -91,9 +81,40 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:100",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:100"
+            ],
+            "sort": 4
+        },
+        {
+            "name": "Mode",
+            "description": "0 = Normal Race\r\n1 = Time Trial\r\n2 = Battle\r\n3 = Soccer\r\n4 = Follow The Leader\r\n5 = Capture the Flag",
+            "env_variable": "MODE",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "in:0,1,2,3,4,5"
+            ],
+            "sort": 5
+        },
+        {
+            "name": "Server Name",
+            "description": "The Name of the Server",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Pterodactyl_Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:50"
+            ],
+            "sort": 6
         }
     ]
 }


### PR DESCRIPTION
# Description
When running the current SuperTuxKart egg, this message prevents dependencies from installing properly

```
E: The repository 'http://deb.debian.org/debian bullseye-backports Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
```
This Pull Request resolves the issue by changing the repository to **bookworm-backports** and adjusts directory check logic to better handle interrupted installations.

JSON meta version updated from PTDL_v2 to PLCN_V3

## Changes
**Updated Debian repository**: Updated install script to use bookworm-backports instead of bullseye-backports. 
**Adjusted directory path check**: Changed `&&` to `||` in the directory existence check to better handle partial/failed installations

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-standalone/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel
