### PR TITLE
feat(hytale): add OAuth token passthrough variables

### DIFF
--- a/hytale/egg-hytale.yaml
+++ b/hytale/egg-hytale.yaml
@@ -106,3 +106,25 @@ variables:
     user_editable: true
     rules:
       - boolean
+  -
+    sort: 7
+    name: 'Session Token'
+    description: 'OAuth session token for server authentication (Method C: Token Passthrough). Leave empty to use interactive auth. See: https://support.hytale.com/hc/en-us/articles/45328341414043'
+    env_variable: HYTALE_SERVER_SESSION_TOKEN
+    default_value: ''
+    user_viewable: true
+    user_editable: true
+    rules:
+      - nullable
+      - string
+  -
+    sort: 8
+    name: 'Identity Token'
+    description: 'OAuth identity token for server authentication (Method C: Token Passthrough). Leave empty to use interactive auth. See: https://support.hytale.com/hc/en-us/articles/45328341414043'
+    env_variable: HYTALE_SERVER_IDENTITY_TOKEN
+    default_value: ''
+    user_viewable: true
+    user_editable: true
+    rules:
+      - nullable
+      - string


### PR DESCRIPTION
## Summary

- Add `HYTALE_SERVER_SESSION_TOKEN` environment variable for OAuth session token passthrough
- Add `HYTALE_SERVER_IDENTITY_TOKEN` environment variable for OAuth identity token passthrough

## Why

Server hosting providers and users who frequently recreate containers lose their authentication when the `auth.enc` file is not persisted. Hytale's Server Provider Authentication Guide documents [Method C: Token Passthrough](https://support.hytale.com/hc/en-us/articles/45328341414043-Server-Provider-Authentication-Guide#method-c-token-passthrough-environmentcli-) which allows passing OAuth tokens via environment variables.

This enables:
- Authentication that survives container recreation
- Centralized token management for hosting providers
- Automated deployment scenarios